### PR TITLE
Add --no-clear as a CLI option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,11 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+tests_require = ['mock']
+
 setup(
     name = "pywatch",
-    version = "0.4",
+    version = "0.5",
     url = 'http://heisel.org/blog/code/pywatch/',
     license = 'MIT',
     description = "Runs arbitrary commands if files specified to be watched change.",

--- a/src/pywatch/__init__.py
+++ b/src/pywatch/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "0.4"
+VERSION = "0.5"
 
 import sys
 

--- a/src/pywatch/__init__.py
+++ b/src/pywatch/__init__.py
@@ -27,6 +27,10 @@ def main(args=None):
                       dest="version",
                       default=False,
                       help="Output verion number and exit.")
+    parser.add_option("--no-clear",
+                      action="store_true",
+                      default=False,
+                      help="Don't clear the terminal when files change.")
     options, args = parser.parse_args(args)
 
     if options.version:
@@ -38,6 +42,6 @@ def main(args=None):
 
     cmds = [args[0], ]
     files = args[1:]
-    w = Watcher(cmds=cmds, files=files, verbose=options.verbose)
+    w = Watcher(cmds=cmds, files=files, verbose=options.verbose, clear=options.no_clear)
     w.run_monitor()
     sys.exit(0)

--- a/src/pywatch/__init__.py
+++ b/src/pywatch/__init__.py
@@ -29,7 +29,7 @@ def main(args=None):
                       help="Output verion number and exit.")
     parser.add_option("--no-clear",
                       action="store_true",
-                      default=False,
+                      default=True,
                       help="Don't clear the terminal when files change.")
     options, args = parser.parse_args(args)
 
@@ -42,6 +42,7 @@ def main(args=None):
 
     cmds = [args[0], ]
     files = args[1:]
+
     w = Watcher(cmds=cmds, files=files, verbose=options.verbose, clear=options.no_clear)
     w.run_monitor()
     sys.exit(0)

--- a/src/pywatch/tests.py
+++ b/src/pywatch/tests.py
@@ -1,6 +1,7 @@
 import os
 import time
 import unittest
+from mock import patch
 
 from pywatch.watcher import Watcher
 
@@ -95,6 +96,20 @@ class WatcherTest(unittest.TestCase):
         self.assertEqual(1, self.watcher.num_runs)
         
         self.watcher.stop_monitor()
+
+    def test_clear_terminal_by_default(self):
+        with patch('pywatch.watcher.os.system') as mocked_system:
+            self.watcher.execute()
+            mocked_system.assert_called_with('clear')
+
+    def test_dont_clear_terminal_when_set(self):
+        with patch('pywatch.watcher.os.system') as mocked_system:
+            self.watcher.clear = False
+            self.watcher.cmds = ['']
+            self.watcher.execute()
+            mocked_system.assert_called_once_with('')
+
+            
 
 def test_suite():
     return unittest.makeSuite(WatcherTest)

--- a/src/pywatch/watcher.py
+++ b/src/pywatch/watcher.py
@@ -4,7 +4,7 @@ import threading
 import time
 
 class Watcher(object):
-    def __init__(self, files=None, cmds=None, verbose=False):
+    def __init__(self, files=None, cmds=None, verbose=False, clear=True):
         self.files = [] 
         self.cmds = []
         self.num_runs = 0
@@ -12,6 +12,7 @@ class Watcher(object):
         self._monitor_continously = False 
         self._monitor_thread = None
         self.verbose = verbose
+        self.clear = clear
     
         if files: self.add_files(*files)
         if cmds: self.add_cmds(*cmds)
@@ -65,6 +66,8 @@ class Watcher(object):
 
     def execute(self):
         if self.verbose: print "Running commands at %s" % (datetime.datetime.now(), )
+        if self.clear:
+            os.system('clear')
         [ os.system(cmd) for cmd in self.cmds ]
         self.num_runs += 1
         return self.num_runs


### PR DESCRIPTION
These changes add `--no-clear` to avoid clearing the terminal every time Watcher().execute() runs. It makes clearing the terminal the default behavior.

The small change is tested and note that the version for pywatch was bumped to 0.5.

I also added test_requires since I needed Mock to patch os.system
