### PR TITLE
python3.3 compatibility + replace --no-clear with --clear

### DIFF
--- a/src/pywatch/__init__.py
+++ b/src/pywatch/__init__.py
@@ -28,10 +28,10 @@ def main(args=None):
                       dest="version",
                       default=False,
                       help="Output verion number and exit.")
-    parser.add_option("--no-clear",
+    parser.add_option("--clear",
                       action="store_true",
-                      default=True,
-                      help="Don't clear the terminal when files change.")
+                      default=False,
+                      help="First clear the terminal when files change.")
     options, args = parser.parse_args(args)
 
     if options.version:
@@ -44,6 +44,6 @@ def main(args=None):
     cmds = [args[0], ]
     files = args[1:]
 
-    w = Watcher(cmds=cmds, files=files, verbose=options.verbose, clear=options.no_clear)
+    w = Watcher(cmds=cmds, files=files, verbose=options.verbose, clear=options.clear)
     w.run_monitor()
     sys.exit(0)

--- a/src/pywatch/__init__.py
+++ b/src/pywatch/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 VERSION = "0.5"
 
 import sys
@@ -34,11 +35,11 @@ def main(args=None):
     options, args = parser.parse_args(args)
 
     if options.version:
-        print "pywatch %s" % VERSION
+        print("pywatch %s" % VERSION)
         sys.exit(0)
 
     if len(args) < 2:
-        print parser.error("You must provide a shell command and at least one file.")
+        print(parser.error("You must provide a shell command and at least one file."))
 
     cmds = [args[0], ]
     files = args[1:]

--- a/src/pywatch/watcher.py
+++ b/src/pywatch/watcher.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 import os
 import threading
@@ -5,15 +6,15 @@ import time
 
 class Watcher(object):
     def __init__(self, files=None, cmds=None, verbose=False, clear=True):
-        self.files = [] 
+        self.files = []
         self.cmds = []
         self.num_runs = 0
         self.mtimes = {}
-        self._monitor_continously = False 
+        self._monitor_continously = False
         self._monitor_thread = None
         self.verbose = verbose
         self.clear = clear
-    
+
         if files: self.add_files(*files)
         if cmds: self.add_cmds(*cmds)
 
@@ -56,16 +57,16 @@ class Watcher(object):
             if f not in self.mtimes.keys():
                 self.mtimes[f] = mtime
                 continue
-            
+
             if mtime > self.mtimes[f]:
-                if self.verbose: print "File changed: %s" % os.path.realpath(f)
+                if self.verbose: print("File changed: %s" % os.path.realpath(f))
                 self.mtimes[f] = mtime
                 if execute:
                     self.execute()
                     break
 
     def execute(self):
-        if self.verbose: print "Running commands at %s" % (datetime.datetime.now(), )
+        if self.verbose: print("Running commands at %s" % (datetime.datetime.now(), ))
         if self.clear:
             os.system('clear')
         [ os.system(cmd) for cmd in self.cmds ]

--- a/src/pywatch/watcher.py
+++ b/src/pywatch/watcher.py
@@ -5,7 +5,7 @@ import threading
 import time
 
 class Watcher(object):
-    def __init__(self, files=None, cmds=None, verbose=False, clear=True):
+    def __init__(self, files=None, cmds=None, verbose=False, clear=False):
         self.files = []
         self.cmds = []
         self.num_runs = 0


### PR DESCRIPTION
I've just simple replaced the print statements to functions, and it works in my python3.3.2 environment.
+
I think it's more logical to use a --clear option and don't do any terminal clear command per default. 
I'm using pywatch in a remote terminal...
