### PR TITLE
Removed clear option (non cross platform), added watching directories, a...

### DIFF
--- a/sample_tasks_file.json
+++ b/sample_tasks_file.json
@@ -1,0 +1,34 @@
+{ 
+    "watchdir" : "C:/Users/dhontecillas/prg/projects/pixeloq/assets", 
+    "newfiles" : false, 
+    "commands" : { 
+        "type" : "type %(FF)s",
+        "copy" : "copy %(FF)s %(PXQBUILDDIR)s\\output\\%(F)s", 
+        "echo" : "echo %(FF)s",
+        "buildimages" : "%(PXQTOOLS)s\\imgtomesh\\imgtomesh.py *.png --indir %(P)s --outdir %(PXQBUILDDIR)s\\output --prefix %(BPC1)s_%(BPC0)s_%(SF)s",
+        "scaffoldData" : "dscaffold.py %(FF)s",    
+        "genappconfig" : "datagen.py %(FF)s jsonparse %(P)s\\..\\..\\..\\src\\Game\\ConfGen",
+        "genconfigdata" : "datagen.py %(FF)s jsonparse %(P)s\\..\\..\\..\\src\\Game\\ConfGen",
+        "genpixelconfig" : "datagen.py %(FF)s jsonparse %(P)s\\..\\..\\..\\src\\Render\\ConfGen" 
+    }, 
+    "matchers" : [ 
+        { "re"       : ".*assets.config.*\\.json", 
+          "commands" : [ "copy" ] 
+        }, 
+        { "re"       : ".*assets.materials.*", 
+          "commands" : [ "copy" ] 
+        },
+        { "re"       : ".*assets.images.*\\.png",
+          "commands" : [ "buildimages" ] 
+        },
+        { "re"       : ".*assets.config.defs.appconfig.dsca", 
+          "commands" : [ "scaffoldData", "genappconfig" ] 
+        },
+        { "re"       : ".assets.config.defs.configdata\\.dsca", 
+          "commands" : [ "scaffoldData", "genconfigdata" ] 
+        }, 
+        { "re"       : ".assets.config.defs.pixelconfig\\.dsca",
+          "commands" : [ "scaffoldData", "genpixelconfig" ] 
+        }
+    ]
+} 

--- a/scripts/pywatch
+++ b/scripts/pywatch
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
-import pywatch
-pywatch.main()
+from pywatch.runwatch import main
+main()

--- a/src/pywatch/__init__.py
+++ b/src/pywatch/__init__.py
@@ -1,49 +1,5 @@
-from __future__ import print_function
-VERSION = "0.5"
+VERSION = "0.4"
 
 import sys
-
-from optparse import OptionParser
-
 from pywatch.watcher import Watcher
 
-def main(args=None):
-    """
-    Used by the pywatch script to handle command-line
-    args.
-    """
-
-    if not args:
-        args = sys.argv[1:]
-
-    usage = 'usage: %prog [options] "command" file1 file2 ...'
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose",
-                      action="store_true",
-                      dest="verbose",
-                      default=False,
-                      help="Output timestamp when commands are run.")
-    parser.add_option("--version",
-                      action="store_true",
-                      dest="version",
-                      default=False,
-                      help="Output verion number and exit.")
-    parser.add_option("--clear",
-                      action="store_true",
-                      default=False,
-                      help="First clear the terminal when files change.")
-    options, args = parser.parse_args(args)
-
-    if options.version:
-        print("pywatch %s" % VERSION)
-        sys.exit(0)
-
-    if len(args) < 2:
-        print(parser.error("You must provide a shell command and at least one file."))
-
-    cmds = [args[0], ]
-    files = args[1:]
-
-    w = Watcher(cmds=cmds, files=files, verbose=options.verbose, clear=options.clear)
-    w.run_monitor()
-    sys.exit(0)

--- a/src/pywatch/commandexecutor.py
+++ b/src/pywatch/commandexecutor.py
@@ -1,0 +1,99 @@
+import os
+import sys
+
+class CommandExecutor(object): 
+    """ 
+        Executes a command having a file as a paramer. 
+        
+        An environment variable can be referred with : %(ENV_VAR_NAME)s 
+
+        A dictionary with custom variables can be added and it
+        generates shortcuts for easy substitution in the command string
+        from the target File / Directory name 
+
+        %(P)s -> the Path for the file 
+        %(F)s -> the File name alone 
+        %(FF)s -> the Fullpath and File name 
+        %(SF)s -> Striped File name without file extension 
+        %(EXT)s -> file EXTension 
+        %(FSF)s -> Fullpath Striped File ( without extension ) 
+        
+        
+        %(BPC0)s -> (Backward Path Component)last path component 
+        %(BPC1)s -> previous one 
+                    ... 
+        %(PC0)s ->  first path component 
+        %(PC1)s ->  next one 
+                    ... 
+
+        %(P2PBC0) -> (Path To Patch Backward Component 0 ) 
+                    ... 
+
+        %(P2PC0) -> (Path To Patch Component 0)  
+
+    """ 
+    def __init__( self, cmd, customenv = {}, verbose = True ): 
+        self.verbose = verbose
+        self.cmd = cmd
+        self.customenv = {}
+        self.customenv.update( os.environ ) 
+        self.customenv.update( customenv ) 
+
+    def constructDictionary( self, fullPath ): 
+        vdic = {}
+        vdic.update( self.customenv )
+        vdic[ 'FF' ] = fullPath
+        
+        # fill the basic file info 
+        if os.path.isdir( fullPath ): 
+            vdic['F'] = ''
+            vdic['EXT'] = '' 
+            vdic['SF'] = '' 
+            vdic['P'] = fullPath
+        else: 
+            vdic['F'] = os.path.basename( fullPath )
+            spext = os.path.splitext( vdic['F'] ) 
+            if len( spext ) >= 2: 
+                vdic['EXT'] = spext[-1] 
+            else: 
+                vdic['EXT'] = ''
+            vdic['SF'] = vdic['F'][:-len( vdic['EXT'])]
+            vdic['P'] = os.path.split( fullPath )[0] 
+
+        vdic['FSF'] = os.path.sep.join( [ vdic['P'], vdic['SF'] ] )
+        
+        comps = vdic['P'].split( os.path.sep ) 
+        n = len( comps )
+        idx = 0
+      
+        
+        if os.path.sep == '/':
+            accumC = [''] 
+        else: 
+            accumC = [] 
+
+        for c in comps:
+            accumC.append( c ) 
+             
+            k = 'PC' + str( idx ) 
+            bk = 'BPC' + str( n - idx -1 )
+            fk = 'P2' + k
+            fbk = 'P2' + bk
+            vdic[ k ] = vdic[ bk ] = c 
+            vdic[ fk ] = vdic[ fbk ] = os.path.sep.join( accumC )
+            idx = idx + 1
+        return vdic 
+
+    def pathToPrefix( self, fullPath, levels = 2 ): 
+        components = fullPath.split( '/' )
+        components = components[-levels:] 
+        return '_'.join( components )
+        
+    def execute( self, filePath ): 
+        filePath = os.path.abspath( filePath ) 
+        s = self.constructDictionary( filePath ) 
+        print self.cmd
+        c = self.cmd % s 
+        if self.verbose : print c 
+        os.system( c )
+        

--- a/src/pywatch/commandexecutor.py
+++ b/src/pywatch/commandexecutor.py
@@ -1,99 +1,100 @@
 import os
 import sys
 
-class CommandExecutor(object): 
-    """ 
-        Executes a command having a file as a paramer. 
-        
-        An environment variable can be referred with : %(ENV_VAR_NAME)s 
+class CommandExecutor(object):
+    """
+        Executes a command having a file as a paramer.
+
+        An environment variable can be referred with : %(ENV_VAR_NAME)s
 
         A dictionary with custom variables can be added and it
         generates shortcuts for easy substitution in the command string
-        from the target File / Directory name 
+        from the target File / Directory name
 
-        %(P)s -> the Path for the file 
-        %(F)s -> the File name alone 
-        %(FF)s -> the Fullpath and File name 
-        %(SF)s -> Striped File name without file extension 
-        %(EXT)s -> file EXTension 
-        %(FSF)s -> Fullpath Striped File ( without extension ) 
-        
-        
-        %(BPC0)s -> (Backward Path Component)last path component 
-        %(BPC1)s -> previous one 
-                    ... 
-        %(PC0)s ->  first path component 
-        %(PC1)s ->  next one 
-                    ... 
+        %(P)s -> the Path for the file
+        %(F)s -> the File name alone
+        %(FF)s -> the Fullpath and File name
+        %(SF)s -> Striped File name without file extension
+        %(EXT)s -> file EXTension
+        %(FSF)s -> Fullpath Striped File ( without extension )
 
-        %(P2PBC0) -> (Path To Patch Backward Component 0 ) 
-                    ... 
 
-        %(P2PC0) -> (Path To Patch Component 0)  
+        %(BPC0)s -> (Backward Path Component)last path component
+        %(BPC1)s -> previous one
+                    ...
+        %(PC0)s ->  first path component
+        %(PC1)s ->  next one
+                    ...
 
-    """ 
-    def __init__( self, cmd, customenv = {}, verbose = True ): 
+        %(P2PBC0) -> (Path To Patch Backward Component 0 )
+                    ...
+
+        %(P2PC0) -> (Path To Patch Component 0)
+
+    """
+    def __init__( self, cmd, customenv = {}, verbose = True ):
         self.verbose = verbose
         self.cmd = cmd
         self.customenv = {}
-        self.customenv.update( os.environ ) 
-        self.customenv.update( customenv ) 
+        self.customenv.update( os.environ )
+        self.customenv.update( customenv )
 
-    def constructDictionary( self, fullPath ): 
+    def constructDictionary( self, fullPath ):
         vdic = {}
         vdic.update( self.customenv )
         vdic[ 'FF' ] = fullPath
-        
-        # fill the basic file info 
-        if os.path.isdir( fullPath ): 
+
+        # fill the basic file info
+        if os.path.isdir( fullPath ):
             vdic['F'] = ''
-            vdic['EXT'] = '' 
-            vdic['SF'] = '' 
+            vdic['EXT'] = ''
+            vdic['SF'] = ''
             vdic['P'] = fullPath
-        else: 
+        else:
             vdic['F'] = os.path.basename( fullPath )
-            spext = os.path.splitext( vdic['F'] ) 
-            if len( spext ) >= 2: 
-                vdic['EXT'] = spext[-1] 
-            else: 
+            spext = os.path.splitext( vdic['F'] )
+            if len( spext ) >= 2:
+                vdic['EXT'] = spext[-1]
+            else:
                 vdic['EXT'] = ''
             vdic['SF'] = vdic['F'][:-len( vdic['EXT'])]
-            vdic['P'] = os.path.split( fullPath )[0] 
+            vdic['P'] = os.path.split( fullPath )[0]
 
         vdic['FSF'] = os.path.sep.join( [ vdic['P'], vdic['SF'] ] )
-        
-        comps = vdic['P'].split( os.path.sep ) 
+
+        comps = vdic['P'].split( os.path.sep )
         n = len( comps )
         idx = 0
-      
-        
+
+
         if os.path.sep == '/':
-            accumC = [''] 
-        else: 
-            accumC = [] 
+            accumC = ['']
+        else:
+            accumC = []
 
         for c in comps:
-            accumC.append( c ) 
-             
-            k = 'PC' + str( idx ) 
+            accumC.append( c )
+
+            k = 'PC' + str( idx )
             bk = 'BPC' + str( n - idx -1 )
             fk = 'P2' + k
             fbk = 'P2' + bk
-            vdic[ k ] = vdic[ bk ] = c 
+            vdic[ k ] = vdic[ bk ] = c
             vdic[ fk ] = vdic[ fbk ] = os.path.sep.join( accumC )
             idx = idx + 1
-        return vdic 
+        return vdic
 
-    def pathToPrefix( self, fullPath, levels = 2 ): 
+    def pathToPrefix( self, fullPath, levels = 2 ):
         components = fullPath.split( '/' )
-        components = components[-levels:] 
+        components = components[-levels:]
         return '_'.join( components )
-        
-    def execute( self, filePath ): 
-        filePath = os.path.abspath( filePath ) 
-        s = self.constructDictionary( filePath ) 
-        print self.cmd
-        c = self.cmd % s 
-        if self.verbose : print c 
+
+    def execute( self, filePath ):
+        filePath = os.path.abspath( filePath )
+        s = self.constructDictionary( filePath )
+        print(self.cmd)
+        c = self.cmd % s
+        if self.verbose :
+            print(c)
         os.system( c )
-        
+

--- a/src/pywatch/filematcher.py
+++ b/src/pywatch/filematcher.py
@@ -1,0 +1,26 @@
+import re 
+
+class FileMatcher(object): 
+    """ Uses a regex to match a file (with the full path),
+        and run commands on it in case it matches the regex """ 
+    
+    def __init__( self, matchRE ): 
+        """ matchRE must be a re string """ 
+        self.matchRE = re.compile( matchRE ) 
+        if self.matchRE is None:
+            print( "Non valid regex: %s" % matchRE )
+        self.cmds = [] 
+
+    def addCmd( self, cmd ):
+        """ adds a CommandExecutor to run when a file matches """ 
+        self.cmds.append( cmd ) 
+
+    def runCmds( self, filePath ): 
+        """ checks if a filePath matches the regex and if so it runs
+            the commands with the filePath as a parameter """ 
+        m = self.matchRE.match( filePath )
+        if m is not None: 
+            for c in self.cmds: 
+                c.execute( filePath ) 
+            return True
+        return False 

--- a/src/pywatch/runwatch.py
+++ b/src/pywatch/runwatch.py
@@ -1,0 +1,70 @@
+import os 
+import sys
+import json
+from optparse import OptionParser
+from watcher import Watcher
+from tasksconfig import TasksConfig
+
+def main(args=None):
+    """
+    Used by the pywatch script to handle command-line
+    args.
+    """
+
+    if not args:
+        args = sys.argv[1:]
+
+    usage = 'usage: %prog [options] "command" file1 file2 ...'
+    parser = OptionParser(usage=usage)
+    parser.add_option("-v", "--verbose",
+                      action="store_true",
+                      dest="verbose",
+                      default=False,
+                      help="Output timestamp when commands are run.")
+    parser.add_option("--version",
+                      action="store_true",
+                      dest="version",
+                      default=False,
+                      help="Output verion number and exit.")
+    parser.add_option("--jsonconf",
+                      dest="jsonconf", 
+                      help="Use advance JSON configuration file to run commands" ) 
+    options, args = parser.parse_args(args)
+
+    if options.version:
+        print "pywatch %s" % VERSION
+        sys.exit(0)
+
+    confile = None 
+    if options.jsonconf is not None: 
+        # Uses the JSON file to configure the main dir and actions to take
+        if not os.path.isfile( options.jsonconf ): 
+            print( "Not valid jsonconf file name" ); 
+        else: 
+            confile = options.jsonconf 
+    elif os.path.isfile( ".tasksconfig.json" ):
+        confile = ".tasksconfig.json" 
+        
+    if confile is not None: 
+        cf = open( confile ) 
+        try: 
+            jconf = json.load( cf )
+        except ValueError:
+            print "Invalid JSON" 
+            cf.close()
+            exit() 
+        cf.close() 
+        tc = TasksConfig( jconf ) 
+        tc.run() 
+    elif len(args) >= 2:
+        # "Classic" operation mode 
+        cmds = [args[0], ]
+        files = args[1:]
+        w = Watcher(cmds=cmds, files=files, verbose=options.verbose)
+        w.run_monitor()
+        sys.exit(0)
+    else: 
+        print parser.error("You must provide a shell command and at least one file.")
+
+if __name__ == "__main__":
+    main()

--- a/src/pywatch/runwatch.py
+++ b/src/pywatch/runwatch.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import sys
 import json
 from optparse import OptionParser
@@ -27,44 +27,44 @@ def main(args=None):
                       default=False,
                       help="Output verion number and exit.")
     parser.add_option("--jsonconf",
-                      dest="jsonconf", 
-                      help="Use advance JSON configuration file to run commands" ) 
+                      dest="jsonconf",
+                      help="Use advance JSON configuration file to run commands" )
     options, args = parser.parse_args(args)
 
     if options.version:
-        print "pywatch %s" % VERSION
+        print("pywatch {}".format(VERSION))
         sys.exit(0)
 
-    confile = None 
-    if options.jsonconf is not None: 
+    confile = None
+    if options.jsonconf is not None:
         # Uses the JSON file to configure the main dir and actions to take
-        if not os.path.isfile( options.jsonconf ): 
-            print( "Not valid jsonconf file name" ); 
-        else: 
-            confile = options.jsonconf 
+        if not os.path.isfile( options.jsonconf ):
+            print( "Not valid jsonconf file name" );
+        else:
+            confile = options.jsonconf
     elif os.path.isfile( ".tasksconfig.json" ):
-        confile = ".tasksconfig.json" 
-        
-    if confile is not None: 
-        cf = open( confile ) 
-        try: 
+        confile = ".tasksconfig.json"
+
+    if confile is not None:
+        cf = open( confile )
+        try:
             jconf = json.load( cf )
         except ValueError:
-            print "Invalid JSON" 
+            print("Invalid JSON")
             cf.close()
-            exit() 
-        cf.close() 
-        tc = TasksConfig( jconf ) 
-        tc.run() 
+            exit()
+        cf.close()
+        tc = TasksConfig( jconf )
+        tc.run()
     elif len(args) >= 2:
-        # "Classic" operation mode 
+        # "Classic" operation mode
         cmds = [args[0], ]
         files = args[1:]
         w = Watcher(cmds=cmds, files=files, verbose=options.verbose)
         w.run_monitor()
         sys.exit(0)
-    else: 
-        print parser.error("You must provide a shell command and at least one file.")
+    else:
+        print(parser.error("You must provide a shell command and at least one file."))
 
 if __name__ == "__main__":
     main()

--- a/src/pywatch/tasksconfig.py
+++ b/src/pywatch/tasksconfig.py
@@ -2,37 +2,37 @@ import sys
 import os
 import json
 
-from commandexecutor import CommandExecutor
-from filematcher import FileMatcher 
-from watcher import Watcher
+from pywatch.commandexecutor import CommandExecutor
+from pywatch.filematcher import FileMatcher
+from pywatch.watcher import Watcher
 
 
-class TasksConfig( object ): 
-    def __init__( self, configDic, verbose = False ): 
+class TasksConfig( object ):
+    def __init__( self, configDic, verbose = False ):
         self.ready = False
         self.verbose = verbose
-        self.watchdir = configDic[ 'watchdir' ] 
-        self.cmds = {} 
-        self.matchers = [] 
+        self.watchdir = configDic[ 'watchdir' ]
+        self.cmds = {}
+        self.matchers = []
 
         commands = configDic[ 'commands' ]
-        matchers = configDic[ 'matchers' ] 
+        matchers = configDic[ 'matchers' ]
 
         if commands is None:
-            return 
+            return
 
-        for c in commands: 
-            self.cmds.update( { c : CommandExecutor( commands[c] ) } )  
+        for c in commands:
+            self.cmds.update( { c : CommandExecutor( commands[c] ) } )
 
-        for m in matchers: 
-            matcher = FileMatcher( m[ 're' ] ) 
-            for mc in m[ 'commands' ]: 
-                if mc in self.cmds: 
-                    matcher.addCmd( self.cmds[ mc ] ) 
+        for m in matchers:
+            matcher = FileMatcher( m[ 're' ] )
+            for mc in m[ 'commands' ]:
+                if mc in self.cmds:
+                    matcher.addCmd( self.cmds[ mc ] )
             self.matchers.append( matcher )
 
-    def run( self ): 
+    def run( self ):
         w = Watcher( files=[ self.watchdir ], cmds=self.matchers, verbose=self.verbose )
-        w.run_monitor() 
+        w.run_monitor()
 
 

--- a/src/pywatch/tasksconfig.py
+++ b/src/pywatch/tasksconfig.py
@@ -1,0 +1,38 @@
+import sys
+import os
+import json
+
+from commandexecutor import CommandExecutor
+from filematcher import FileMatcher 
+from watcher import Watcher
+
+
+class TasksConfig( object ): 
+    def __init__( self, configDic, verbose = False ): 
+        self.ready = False
+        self.verbose = verbose
+        self.watchdir = configDic[ 'watchdir' ] 
+        self.cmds = {} 
+        self.matchers = [] 
+
+        commands = configDic[ 'commands' ]
+        matchers = configDic[ 'matchers' ] 
+
+        if commands is None:
+            return 
+
+        for c in commands: 
+            self.cmds.update( { c : CommandExecutor( commands[c] ) } )  
+
+        for m in matchers: 
+            matcher = FileMatcher( m[ 're' ] ) 
+            for mc in m[ 'commands' ]: 
+                if mc in self.cmds: 
+                    matcher.addCmd( self.cmds[ mc ] ) 
+            self.matchers.append( matcher )
+
+    def run( self ): 
+        w = Watcher( files=[ self.watchdir ], cmds=self.matchers, verbose=self.verbose )
+        w.run_monitor() 
+
+


### PR DESCRIPTION
I've made major changes to the code in order to track newly created files in a directory. I've base my modification on the 0.4 version, because I like the python code to be cross platform and the --clear option does not work in Windows. 

I've also put a new config mode using a json file (there is a sample that I use for my own game build pipeline), where you can put a directory to watch, and define a list of commands. Those commands can access environment vars and also some pre-built vars that you can use (see the code on CommandExecutor) so you can have easy access to path components of the file changed.

Then there are the FileMatcher class, or mathers, that are only a regex, that if matches, the commands will be run on that file. 

I know that is a big change, and perhaps you will reject this pull request, but I needed this functionality. Since I've based my work on yours, I think it's fair to let you choose if you want it in your repo.
