### PR TITLE
README: Add note explaining the install command.

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,14 @@ Options:
   -v, --verbose  Output timestamp when commands are run.
   --version      Output version number and exit
 
+Installation
+------------
+
+To install pywatch as a global command, from this repository, use:
+
+    python2 setup.py install
+
+
 Changelog
 ---------
 0.4


### PR DESCRIPTION
In Ubuntu 16.04, you can no longer install pywatch from pip and have it work.  As such, it may be useful to others after me to clarify the simple install process in the readme.

Fixes #8 
